### PR TITLE
Adds `nautobot-server celery` management command

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     tty: true
   celery_worker:
     image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
-    entrypoint: "nautobot-server celery -A nautobot.core worker -B -l INFO"
+    entrypoint: "nautobot-server celery worker -B -l INFO"
     depends_on:
       - nautobot
       - redis

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     tty: true
   celery_worker:
     image: "networktocode/nautobot-dev-py${PYTHON_VER}:local"
-    entrypoint: "celery -A nautobot.core worker -B -l INFO"
+    entrypoint: "nautobot-server celery -A nautobot.core worker -B -l INFO"
     depends_on:
       - nautobot
       - redis

--- a/nautobot/core/celery.py
+++ b/nautobot/core/celery.py
@@ -10,12 +10,17 @@ from kombu.serialization import register
 
 logger = logging.getLogger(__name__)
 
-# First, we need to call setup on the app to initialize settings.
-# Note this will set the `DJANGO_SETTINGS_MODULE` environment variable which
-# Celery and its workers need under the hood. The Celery docs and examples
+# The Celery documentation tells us to call setup on the app to initialize
+# settings, but we will NOT be doing that because of a chicken-and-egg problem
+# when bootstrapping the Django settings with `nautobot-server`.
+#
+# Note this would normally set the `DJANGO_SETTINGS_MODULE` environment variable
+# which Celery and its workers need under the hood.The Celery docs and examples
 # normally have you set it here, but because of our custom settings bootstrapping
-# it is handled in the setup call.
-nautobot.setup()
+# it is handled in the `nautobot.setup() call, and we have implemented a
+# `nautobot-server celery` command to provide the correct context so this does
+# NOT need to be called here.
+# nautobot.setup()
 
 app = Celery("nautobot")
 

--- a/nautobot/core/management/commands/celery.py
+++ b/nautobot/core/management/commands/celery.py
@@ -1,0 +1,24 @@
+import sys
+
+from celery.bin.celery import celery as celery_main
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Thin wrapper to the `celery` command that includes the Nautobot Celery
+    app context. This allows us to execute Celery commands without having to
+    worry about the chicken-and-egg problem with bootstrapping the Django
+    settings.
+    """
+
+    def run_from_argv(self, argv):
+
+        # The "celery" command uses Click, which directly relies upon
+        # `sys.argv`. So we must explicitly remove "celery" from `sys.argv` so
+        # that we can directly invoke Click ourselves, letting it work with the
+        # args unhindered as if "celery" instead of "nautobot-server" were the
+        # root command that was called from the CLI.
+        sys.argv.remove("celery")
+
+        celery_main.main()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: n/a
<!--
    Please include a summary of the proposed changes below.
-->

- Commented out `nautobot.setup()` call from `nautobot/core/management/commands/celery.py` and adds more context as to why it's not called there.
- Updated `celery_worker` to use `nautobot-server celery` inside of `development/docker-compose.yml`

Tests are still busted, but I didn't want to inter-mingle fixes w/ this addition.